### PR TITLE
Fix wagons setup by re-creating the Wagonfile after the Docker build

### DIFF
--- a/.docker/entrypoint
+++ b/.docker/entrypoint
@@ -2,6 +2,14 @@
 
 set +e
 
+if [ ! -f "./Wagonfile" ]; then
+  echo "⚙ Creating Wagonfile from defaults because it doesn't exist yet"
+  bundle exec rake wagon:file
+  echo "✅ Created Wagonfile"
+else
+  echo "↪️ Leaving existing Wagonfile as it is"
+fi
+
 echo "⚙️ Testing DB connection"
 timeout 300s waitfortcp "${RAILS_DB_HOST-db}" "${RAILS_DB_PORT-3306}"
 echo "✅ DB is ready"

--- a/.docker/entrypoint
+++ b/.docker/entrypoint
@@ -4,7 +4,7 @@ set +e
 
 if [ ! -f "./Wagonfile" ]; then
   echo "⚙ Creating Wagonfile from defaults because it doesn't exist yet"
-  bundle exec rake wagon:file
+  cp ./Wagonfile.ci ./Wagonfile
   echo "✅ Created Wagonfile"
 else
   echo "↪️ Leaving existing Wagonfile as it is"


### PR DESCRIPTION
As also discussed in #2, the Wagonfile is copied from Wagonfile.ci during the docker image build. However, this Wagonfile is subsequently
1. overwritten in https://github.com/nxt-engineering/hitobito-docker/blob/5d6f00f262584fd224187ed5765c83edf87bc12b/Dockerfile#L14
2. overlaid by the mount in docker-compose.

#2 proposes to mention in the documentation that the Wagonfile needs to be copied manually. Since the goal of this repository is to simplify the setup as far as possible, this PR instead creates the Wagonfile again in the entrypoint (unless it exists already).
This removes support for setups without Wagonfiles, but [hitobito requires at least one wagon](https://github.com/hitobito/hitobito/blame/master/README.md#L89) anyways.